### PR TITLE
make xhr async

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -56,22 +56,25 @@ var sendMetadata = function(f) {
             result = statusLineArray[1];
 
         var xhr = new XMLHttpRequest();
-        /*
-          TODO: stop hardcoding development stuffs
-         */
         var url = "http://debbiedeth.osb.ft.com:32780/"
-        xhr.open("POST", url, false);
 
-        xhr.send(JSON.stringify(f));
-
-        if (xhr.status == 200) {
+        xhr.addEventListener('load', (event) => {
             status.appendChild(success(result));
             f.metdataUrl = url + JSON.parse(xhr.response).uuid;
             resolve(f);
-        } else {
+        });
+
+        xhr.addEventListener('error', (event) => {
             status.appendChild(failure(result, xhr.statusText));
             reject(f);
-        }
+        })
+
+        /*
+          TODO: stop hardcoding development stuffs
+         */
+        xhr.open("POST", url);
+
+        xhr.send(JSON.stringify(f));
     });
 };
 


### PR DESCRIPTION
Makes the XHR async, as synchronous XMLHTTPRequests are [discouraged by mdn](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests):

> Note: Starting with Gecko 30.0 (Firefox 30.0 / Thunderbird 30.0 / SeaMonkey 2.27), synchronous requests on the main thread have been deprecated due to the negative effects to the user experience.
